### PR TITLE
feat(vm): add nixosConfigurations.vm for smoke tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,28 @@
       ];
     };
 
+    # Minimal VM configuration for smoke tests
+    nixosConfigurations.vm = nixpkgs.lib.nixosSystem {
+      system = system;
+      modules = [
+        nvf.nixosModules.default
+        ./modules/common.nix
+        ./modules/vm-guest.nix
+        {
+          networking.hostName = "vm";
+          # A minimal root filesystem to satisfy NixOS assertions for VM builds
+          fileSystems."/" = {
+            device = "nodev";
+            fsType = "tmpfs";
+            options = ["mode=0755"];
+          };
+          # No bootloader needed for qemu-vm builder
+          boot.loader.grub.enable = false;
+          boot.loader.systemd-boot.enable = false;
+        }
+      ];
+    };
+
     # per-system outputs
     devShells.${system}.default = pkgs.mkShell {
       buildInputs = with pkgs; [git sops age just statix deadnix alejandra];

--- a/modules/vm-guest.nix
+++ b/modules/vm-guest.nix
@@ -1,5 +1,4 @@
 {...}: {
   services.qemuGuest.enable = true;
   services.spice-vdagentd.enable = true;
-  virtualisation.qemu.guestAgent.enable = true;
 }


### PR DESCRIPTION
Adds nixosConfigurations.vm importing modules/vm-guest.nix (QEMU guest + SPICE) and a minimal tmpfs root with bootloader disabled for qemu-vm builds. This enables instant smoke tests via:\n\n\n\nAlso trims a non-existent option from modules/vm-guest.nix.
