### PR TITLE
chore(dev): golden environment extras (pre-commit, devshell, Justfile, CI)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,5 +1,9 @@
 name: nix
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 9 * * *" # daily lockfile update PR
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -8,4 +12,26 @@ jobs:
       - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: experimental-features = nix-command flakes
-      - run: nix flake check
+      - name: Enable Cachix (pull cache; push iff token provided)
+        if: ${{ secrets.CACHIX_AUTH_TOKEN != '' }}
+        uses: cachix/cachix-action@v15
+        with:
+          name: mangano
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Format check
+        run: nix fmt -- --check
+      - name: Flake checks
+        run: nix flake check --print-build-logs
+      - name: Pre-commit hooks (optional)
+        run: nix build .#packages.x86_64-linux.pre-commit-check
+        continue-on-error: true
+
+  update-lock:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          pr-title: "chore: update flake.lock"
+          pr-labels: dependencies

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,23 @@
+# Justfile
+system := "x86_64-linux"
+
+default: help
+
+help:
+	@just --list
+
+fmt:
+	nix fmt .
+
+check:
+	nix flake check --print-build-logs
+
+update:
+	nix flake update
+
+switch:
+	sudo nixos-rebuild switch --flake .#nymeria
+
+vm:
+	nix build .#nixosConfigurations.vm.config.system.build.vm
+	./result/bin/run-nixos-vm

--- a/docs/REFRESH.md
+++ b/docs/REFRESH.md
@@ -39,10 +39,14 @@ sudo nixos-install --flake .#nymeria
 ```
 
 ## VM smoke test
-You can build a QEMU VM from the nymeria config (useful for quick checks):
+Fast local smoke test using the dedicated VM config:
 ```bash
-nix build .#nixosConfigurations.nymeria.config.system.build.vm
+# build & run
+nix build .#nixosConfigurations.vm.config.system.build.vm
 ./result/bin/run-nixos-vm
+
+# or via Just
+just vm
 ```
 
 ## Secrets (sops-nix)
@@ -58,12 +62,18 @@ nix build .#nixosConfigurations.nymeria.config.system.build.vm
 
 ## Useful flake commands
 ```bash
-# Lint (defined in flake checks)
-nix flake check
+# Lint & build checks
+nix flake check --print-build-logs
 
-# Dev shell with tools (statix, deadnix, alejandra, etc.)
+# Dev shell with tools (alejandra, statix, deadnix, nil, nom, pre-commit)
 nix develop
 
 # Format all Nix files via flake formatter
 nix fmt .
+```
+
+## Pre-commit hooks
+When entering the dev shell, pre-commit hooks are auto-installed. To run all hooks manually:
+```bash
+nix build .#checks.x86_64-linux.pre-commit
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -36,6 +36,22 @@
         "url": "https://git.lix.systems/lix-project/flake-compat.git"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -54,6 +70,27 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -147,6 +184,28 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1759523803,
+        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "disko": "disko",
@@ -154,6 +213,7 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "nvf": "nvf",
+        "pre-commit-hooks": "pre-commit-hooks",
         "sops-nix": "sops-nix"
       }
     },


### PR DESCRIPTION
This PR adds golden dev-environment extras:

- Flake inputs: pre-commit-hooks.nix
- DevShell: nil, nix-output-monitor, pre-commit + auto-install hooks
- Checks: build nymeria toplevel and VM
- Packages: Nix-native pre-commit runner at `. #packages.x86_64-linux.pre-commit-check`
- CI: format check, flake check with logs, optional Cachix, daily lockfile PR
- Docs: REFRESH.md updates (VM target, pre-commit), and a Justfile (fmt, check, update, switch, vm)

Notes:
- The pre-commit runner is provided as a package and marked optional in CI to avoid breaking builds while we address lint issues.
- After merging, you can enable cache pushes by adding CACHIX_AUTH_TOKEN (GitHub secret) if you want.

Thanks!
