### PR TITLE
Add ZFS disko layouts for nymeria hosts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,58 @@
+# Install guide
+
+## VMware VM (⚠ wipes target disk)
+```bash
+nix run github:nix-community/disko -- \
+  --mode zap_create_mount \
+  --flake <REPO_PATH>#nymeria-vmware
+```
+
+## KVM/QEMU VM (⚠ wipes target disk)
+```bash
+nix run github:nix-community/disko -- \
+  --mode zap_create_mount \
+  --flake <REPO_PATH>#nymeria-kvm
+```
+
+## Bare metal ZFS (⚠ wipes target disk)
+1. Edit `modules/disko/baremetal-zfs-encrypted.nix` and replace the by-id device(s).
+2. Then run:
+
+```bash
+nix run github:nix-community/disko -- \
+  --mode zap_create_mount \
+  --flake <REPO_PATH>#nymeria
+```
+
+After any of the above:
+```bash
+nixos-generate-config --root /mnt
+```
+
+Copy the generated hardware config into the matching host folder (only if it doesn't already exist or you're updating it):
+```bash
+cp /mnt/etc/nixos/hardware-configuration.nix <REPO_PATH>/hosts/<host>/hardware-configuration.nix
+cd <REPO_PATH>
+git add hosts/<host>/hardware-configuration.nix
+git commit -m "chore(host): add hardware-configuration.nix for <host>"
+```
+
+Install:
+```bash
+nixos-install --flake <REPO_PATH>#<host>
+```
+
+Reboot, then from the installed system:
+```bash
+sudo nixos-rebuild switch --flake /etc/nixos#<host>
+```
+
+## Parametric one-off (override device on the fly)
+```bash
+nix run github:nix-community/disko -- \
+  --mode zap_create_mount \
+  --argstr device /dev/sda \
+  --argstr pool rpool \
+  --argstr ashift 12 \
+  --config <REPO_PATH>/modules/disko/vm-zfs-generic.nix
+```

--- a/flake.nix
+++ b/flake.nix
@@ -38,55 +38,135 @@
     system = "x86_64-linux";
     pkgs = import nixpkgs {inherit system;};
   in {
-    nixosConfigurations.nymeria = nixpkgs.lib.nixosSystem {
-      system = system;
+    nixosConfigurations = {
+      nymeria = nixpkgs.lib.nixosSystem {
+        system = system;
 
-      modules = [
-        ./hosts/nymeria/hardware-configuration.nix
-        ./modules/common.nix
-        ./modules/desktop.nix
-        ./hosts/nymeria/config.nix
+        modules = [
+          ./hosts/nymeria/hardware-configuration.nix
+          ./modules/common.nix
+          ./modules/desktop.nix
+          ./hosts/nymeria/config.nix
 
-        # Optional imports (uncomment and adjust as needed):
-        # nixos-hardware.nixosModules.lenovo-thinkpad-x1-9th-gen
-        # disko.nixosModules.disko
+          # Optional imports (uncomment and adjust as needed):
+          # nixos-hardware.nixosModules.lenovo-thinkpad-x1-9th-gen
 
-        # Existing modules preserved
-        nvf.nixosModules.default
-        sops-nix.nixosModules.sops
-        home-manager.nixosModules.home-manager
-        {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-          # Back up conflicting files instead of failing activation
-          home-manager.backupFileExtension = "backup";
-          # Make sops-nix options available to Home Manager
-          home-manager.sharedModules = [sops-nix.homeManagerModules.sops];
-          home-manager.users.matthew = import ./home/matthew.nix;
-        }
-      ];
-    };
+          disko.nixosModules.disko
+          ./modules/disko/baremetal-zfs-encrypted.nix
 
-    # Minimal VM configuration for smoke tests
-    nixosConfigurations.vm = nixpkgs.lib.nixosSystem {
-      system = system;
-      modules = [
-        nvf.nixosModules.default
-        ./modules/common.nix
-        ./modules/vm-guest.nix
-        {
-          networking.hostName = "vm";
-          # A minimal root filesystem to satisfy NixOS assertions for VM builds
-          fileSystems."/" = {
-            device = "nodev";
-            fsType = "tmpfs";
-            options = ["mode=0755"];
-          };
-          # No bootloader needed for qemu-vm builder
-          boot.loader.grub.enable = false;
-          boot.loader.systemd-boot.enable = false;
-        }
-      ];
+          # Existing modules preserved
+          nvf.nixosModules.default
+          sops-nix.nixosModules.sops
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            # Back up conflicting files instead of failing activation
+            home-manager.backupFileExtension = "backup";
+            # Make sops-nix options available to Home Manager
+            home-manager.sharedModules = [sops-nix.homeManagerModules.sops];
+            home-manager.users.matthew = import ./home/matthew.nix;
+          }
+          ({config, ...}: {
+            boot.supportedFilesystems = ["zfs"];
+            networking.hostId = builtins.substring 0 8 (builtins.hashString "sha256" config.networking.hostName);
+            boot.zfs.devNodes = "/dev/disk/by-id";
+            services.zfs.autoScrub.enable = true;
+            services.zfs.trim.enable = true;
+            zramSwap.enable = true;
+          })
+        ];
+      };
+
+      nymeria-vmware = nixpkgs.lib.nixosSystem {
+        system = system;
+
+        modules = [
+          ./hosts/nymeria-vmware/hardware-configuration.nix
+          ./modules/common.nix
+          ./modules/desktop.nix
+          ./hosts/nymeria-vmware/config.nix
+
+          disko.nixosModules.disko
+          ./modules/disko/vmware-zfs.nix
+          ./modules/vmware-guest.nix
+
+          nvf.nixosModules.default
+          sops-nix.nixosModules.sops
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.backupFileExtension = "backup";
+            home-manager.sharedModules = [sops-nix.homeManagerModules.sops];
+            home-manager.users.matthew = import ./home/matthew.nix;
+          }
+          ({config, ...}: {
+            boot.supportedFilesystems = ["zfs"];
+            networking.hostId = builtins.substring 0 8 (builtins.hashString "sha256" config.networking.hostName);
+            boot.zfs.devNodes = "/dev/disk/by-id";
+            services.zfs.autoScrub.enable = true;
+            services.zfs.trim.enable = true;
+            zramSwap.enable = true;
+          })
+        ];
+      };
+
+      nymeria-kvm = nixpkgs.lib.nixosSystem {
+        system = system;
+
+        modules = [
+          ./hosts/nymeria-kvm/hardware-configuration.nix
+          ./modules/common.nix
+          ./modules/desktop.nix
+          ./hosts/nymeria-kvm/config.nix
+
+          disko.nixosModules.disko
+          ./modules/disko/kvm-zfs.nix
+          ./modules/qemu-guest.nix
+
+          nvf.nixosModules.default
+          sops-nix.nixosModules.sops
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.backupFileExtension = "backup";
+            home-manager.sharedModules = [sops-nix.homeManagerModules.sops];
+            home-manager.users.matthew = import ./home/matthew.nix;
+          }
+          ({config, ...}: {
+            boot.supportedFilesystems = ["zfs"];
+            networking.hostId = builtins.substring 0 8 (builtins.hashString "sha256" config.networking.hostName);
+            boot.zfs.devNodes = "/dev/disk/by-id";
+            services.zfs.autoScrub.enable = true;
+            services.zfs.trim.enable = true;
+            zramSwap.enable = true;
+          })
+        ];
+      };
+
+      # Minimal VM configuration for smoke tests
+      vm = nixpkgs.lib.nixosSystem {
+        system = system;
+        modules = [
+          nvf.nixosModules.default
+          ./modules/common.nix
+          ./modules/vm-guest.nix
+          {
+            networking.hostName = "vm";
+            # A minimal root filesystem to satisfy NixOS assertions for VM builds
+            fileSystems."/" = {
+              device = "nodev";
+              fsType = "tmpfs";
+              options = ["mode=0755"];
+            };
+            # No bootloader needed for qemu-vm builder
+            boot.loader.grub.enable = false;
+            boot.loader.systemd-boot.enable = false;
+          }
+        ];
+      };
     };
 
     # per-system outputs
@@ -124,6 +204,8 @@
       };
 
       nymeria = self.nixosConfigurations.nymeria.config.system.build.toplevel;
+      nymeria-vmware = self.nixosConfigurations.nymeria-vmware.config.system.build.toplevel;
+      nymeria-kvm = self.nixosConfigurations.nymeria-kvm.config.system.build.toplevel;
       vm = self.nixosConfigurations.vm.config.system.build.vm;
     };
 

--- a/hosts/nymeria-kvm/config.nix
+++ b/hosts/nymeria-kvm/config.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  imports = [
+    ../../modules/core/networking.nix
+    ../../modules/core/bootloader.nix
+    ../../modules/core/mozillavpn.nix
+    ../../modules/core/cloudflare-warp.nix
+    ../../modules/core/vpn-killswitch.nix
+  ];
+
+  networking.hostName = lib.mkForce "nymeria-kvm";
+}

--- a/hosts/nymeria-kvm/hardware-configuration.nix
+++ b/hosts/nymeria-kvm/hardware-configuration.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  boot.initrd.availableKernelModules = ["xhci_pci" "ahci" "virtio_pci" "virtio_blk" "virtio_scsi"];
+  boot.initrd.kernelModules = [];
+  boot.kernelModules = [];
+  boot.extraModulePackages = [];
+
+  swapDevices = [];
+
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/hosts/nymeria-vmware/config.nix
+++ b/hosts/nymeria-vmware/config.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  imports = [
+    ../../modules/core/networking.nix
+    ../../modules/core/bootloader.nix
+    ../../modules/core/mozillavpn.nix
+    ../../modules/core/cloudflare-warp.nix
+    ../../modules/core/vpn-killswitch.nix
+  ];
+
+  networking.hostName = lib.mkForce "nymeria-vmware";
+}

--- a/hosts/nymeria-vmware/hardware-configuration.nix
+++ b/hosts/nymeria-vmware/hardware-configuration.nix
@@ -1,0 +1,22 @@
+{  
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  boot.initrd.availableKernelModules = ["xhci_pci" "ahci" "nvme" "usb_storage" "sd_mod"];
+  boot.initrd.kernelModules = [];
+  boot.kernelModules = [];
+  boot.extraModulePackages = [];
+
+  swapDevices = [];
+
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/hosts/nymeria/hardware-configuration.nix
+++ b/hosts/nymeria/hardware-configuration.nix
@@ -17,28 +17,9 @@
   boot.kernelModules = ["kvm-intel"];
   boot.extraModulePackages = [];
 
-  fileSystems."/" = {
-    device = "/dev/disk/by-uuid/1a289702-06c7-4727-94bc-9935d1835c04";
-    fsType = "ext4";
-  };
+  swapDevices = [];
 
-  fileSystems."/boot" = {
-    device = "/dev/disk/by-uuid/6F18-BE10";
-    fsType = "vfat";
-    options = ["fmask=0077" "dmask=0077"];
-  };
-
-  swapDevices = [
-    {device = "/dev/disk/by-uuid/cddaeace-e784-498f-b81a-6dd048816cea";}
-  ];
-
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp0s20f0u4.useDHCP = lib.mkDefault true;
-  # networking.interfaces.wlp0s20f3.useDHCP = lib.mkDefault true;
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;

--- a/modules/disko/baremetal-zfs-encrypted.nix
+++ b/modules/disko/baremetal-zfs-encrypted.nix
@@ -1,0 +1,47 @@
+{ ... }:
+let
+  disk0 = "/dev/disk/by-id/REPLACE_ME";
+in
+{
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      device = disk0;
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            size = "512MiB"; type = "EF00";
+            content = { type = "filesystem"; format = "vfat"; mountpoint = "/boot"; };
+          };
+          zfs = {
+            size = "100%";
+            content = { type = "zfs"; pool = "rpool"; };
+          };
+        };
+      };
+    };
+
+    # For mirror (example):
+    # disk.mirror1 = { ... same with device = "/dev/disk/by-id/REPLACE_ME_2"; content = { type="gpt"; ... }; }
+
+    zpool.rpool = {
+      type = "zpool";
+      mode = "single"; # change to "mirror" and list both disks in members if you add mirror devices
+      options = { ashift = "12"; autotrim = "on"; };
+      rootFsOptions = {
+        atime = "off"; compression = "zstd"; xattr = "sa"; acltype = "posixacl"; mountpoint = "none";
+      };
+      datasets = {
+        "rpool/root" = {
+          type = "zfs_fs"; mountpoint = "/";
+          options = { canmount = "noauto"; encryption = "on"; keyformat = "passphrase"; keylocation = "prompt"; };
+        };
+        "rpool/nix"  = { type = "zfs_fs"; mountpoint = "/nix"; };
+        "rpool/home" = { type = "zfs_fs"; mountpoint = "/home"; };
+        "rpool/var_log" = { type = "zfs_fs"; mountpoint = "/var/log"; };
+        # "rpool/swap" = { type = "zfs_zvol"; size = "16G"; options = { compression = "zle"; sync = "always"; logbias = "throughput"; }; };
+      };
+    };
+  };
+}

--- a/modules/disko/kvm-zfs.nix
+++ b/modules/disko/kvm-zfs.nix
@@ -1,0 +1,1 @@
+(import ./vm-zfs-generic.nix { device = "/dev/vda"; pool = "rpool"; ashift = "12"; })

--- a/modules/disko/vm-zfs-generic.nix
+++ b/modules/disko/vm-zfs-generic.nix
@@ -1,0 +1,47 @@
+# modules/disko/vm-zfs-generic.nix
+{ device, pool ? "rpool", ashift ? "12" }:
+{
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      inherit device;
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            size = "512MiB"; type = "EF00";
+            content = { type = "filesystem"; format = "vfat"; mountpoint = "/boot"; };
+          };
+          zfs = {
+            size = "100%";
+            content = { type = "zfs"; pool = pool; };
+          };
+        };
+      };
+    };
+
+    zpool.${pool} = {
+      type = "zpool";
+      mode = "single";
+      options = {
+        ashift = ashift;       # 12 for SSD/NVMe
+        autotrim = "on";
+      };
+      rootFsOptions = {
+        atime = "off";
+        compression = "zstd";
+        xattr = "sa";
+        acltype = "posixacl";
+        mountpoint = "none";   # datasets set mountpoints
+      };
+      datasets = {
+        "${pool}/root" = { type = "zfs_fs"; mountpoint = "/"; options = { canmount = "noauto"; }; };
+        "${pool}/nix"  = { type = "zfs_fs"; mountpoint = "/nix"; };
+        "${pool}/home" = { type = "zfs_fs"; mountpoint = "/home"; };
+        "${pool}/var_log" = { type = "zfs_fs"; mountpoint = "/var/log"; };
+        # Example zvol swap (DISABLED; prefer zram)
+        # "${pool}/swap" = { type = "zfs_zvol"; size = "8G"; options = { compression = "zle"; sync = "always"; logbias = "throughput"; }; };
+      };
+    };
+  };
+}

--- a/modules/disko/vmware-zfs.nix
+++ b/modules/disko/vmware-zfs.nix
@@ -1,0 +1,1 @@
+(import ./vm-zfs-generic.nix { device = "/dev/nvme0n1"; pool = "rpool"; ashift = "12"; })

--- a/modules/qemu-guest.nix
+++ b/modules/qemu-guest.nix
@@ -1,0 +1,6 @@
+{ ... }: {
+  services.qemuGuestAgent.enable = true;
+  zramSwap.enable = true;
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+}

--- a/modules/vmware-guest.nix
+++ b/modules/vmware-guest.nix
@@ -1,0 +1,6 @@
+{ ... }: {
+  services.open-vm-tools.enable = true;
+  zramSwap.enable = true;
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+}


### PR DESCRIPTION
## Summary
- add disko-backed ZFS layouts for bare metal, VMware, and KVM nymeria hosts and enable guest tooling
- wire new host configurations into the flake with required ZFS defaults and host hardware profiles
- document ISO installation flow with disko one-liners and hardware configuration workflow

## Testing
- ⚠️ `nix flake metadata` *(fails: `nix` command is not available in the execution environment)*
- ⚠️ `nix flake show` *(fails: `nix` command is not available in the execution environment)*
- ⚠️ `nix build .#nixosConfigurations.nymeria.config.system.build.toplevel` *(fails: `nix` command is not available in the execution environment)*
- ⚠️ `nix build .#nixosConfigurations.nymeria-vmware.config.system.build.toplevel` *(fails: `nix` command is not available in the execution environment)*
- ⚠️ `nix build .#nixosConfigurations.nymeria-kvm.config.system.build.toplevel` *(fails: `nix` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8350b25ac832f9875e3b574b217dd